### PR TITLE
Fix install for windows 2012

### DIFF
--- a/packages/golang-windows/packaging
+++ b/packages/golang-windows/packaging
@@ -3,4 +3,10 @@ trap { $host.SetShouldExit(1) }
 
 $BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
 $path=(Get-ChildItem "golang/go*.windows-amd64.zip").FullName
-Expand-Archive -Path $path -DestinationPath ${BOSH_INSTALL_TARGET}
+
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+  Expand-Archive -Path $path -DestinationPath ${BOSH_INSTALL_TARGET}
+} else {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($path, ${BOSH_INSTALL_TARGET})
+}


### PR DESCRIPTION
Expand-Archive is not defined in the stock powershell that we are using
on 2012

[#154365442]

Signed-off-by: Jason Smith <jsmith@pivotal.io>