### PR TITLE
Windows tools compatability issues.

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -42,6 +42,10 @@ processhacker/processhacker-2.39-bin.zip:
   size: 3392412
   object_id: 52e8388f-8ea2-4a7e-5a38-acc1982023d3
   sha: 8e8f8423d163d922242b8b7d85427664f77edc97
+perl64/strawberry-perl-5.26.1.1-64bit.msi:
+  size: 99017793
+  object_id: 2a69a764-bd03-405f-4b7c-9d0d4b281aac
+  sha: 871668bc5b45b8ba2a319602a6592c5e18d88cce
 ruby/ruby-2.3.3-x64.exe:
   size: 19668866
   object_id: 331c4055-4638-4076-5e25-4c22217c5c55

--- a/jobs/cmake/templates/pre-start.ps1
+++ b/jobs/cmake/templates/pre-start.ps1
@@ -9,7 +9,10 @@ if (!$mtx.WaitOne(5000)) {
 
 $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
 $AddedFolder='C:\var\vcap\packages\cmake\bin'
-$NewPath=$OldPath+';'+$AddedFolder
-Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+if (-not $OldPath.Contains($AddedFolder)) {
+  $NewPath=$OldPath+';'+$AddedFolder
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+}
 
 $mtx.ReleaseMutex()

--- a/jobs/mingw32/spec
+++ b/jobs/mingw32/spec
@@ -7,3 +7,8 @@ templates:
 packages:
 - mingw32
 
+properties:
+  mingw32.install_on_path:
+    description: "Install on $PATH"
+    default: false
+

--- a/jobs/mingw32/templates/pre-start.ps1.erb
+++ b/jobs/mingw32/templates/pre-start.ps1.erb
@@ -1,17 +1,21 @@
 ﻿$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-$mtx = New-Object System.Threading.Mutex($false, "PathMutex")
-
-if (!$mtx.WaitOne(5000)) {
-  throw "Could not acquire PATH mutex"
-}
-
 $Mingw32Root='C:\var\vcap\packages\mingw32\mingw32'
 
-$OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-$AddedFolder="$Mingw32Root\bin"
-$NewPath=$OldPath+';'+$AddedFolder
-Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+$installOnPath = [bool]$<%= p("mingw32.install_on_path") %>
 
-$mtx.ReleaseMutex()
+if ($installOnPath) {
+  $mtx = New-Object System.Threading.Mutex($false, "PathMutex")
+
+  if (!$mtx.WaitOne(5000)) {
+    throw "Could not acquire PATH mutex"
+  }
+
+  $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
+  $AddedFolder="$Mingw32Root\bin"
+  $NewPath=$OldPath+';'+$AddedFolder
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+  $mtx.ReleaseMutex()
+}

--- a/jobs/mingw32/templates/pre-start.ps1.erb
+++ b/jobs/mingw32/templates/pre-start.ps1.erb
@@ -1,8 +1,6 @@
 ﻿$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-$Mingw32Root='C:\var\vcap\packages\mingw32\mingw32'
-
 $installOnPath = [bool]$<%= p("mingw32.install_on_path") %>
 
 if ($installOnPath) {
@@ -13,9 +11,12 @@ if ($installOnPath) {
   }
 
   $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-  $AddedFolder="$Mingw32Root\bin"
-  $NewPath=$OldPath+';'+$AddedFolder
-  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+  $AddedFolder="C:\var\vcap\packages\mingw32\mingw32\bin"
+
+  if (-not $OldPath.Contains($AddedFolder)) {
+    $NewPath=$OldPath+';'+$AddedFolder
+    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+  }
 
   $mtx.ReleaseMutex()
 }

--- a/jobs/mingw32/templates/pre-start.ps1.erb
+++ b/jobs/mingw32/templates/pre-start.ps1.erb
@@ -1,1 +1,17 @@
-﻿Write-Host "Installed mingw32"
+﻿$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$mtx = New-Object System.Threading.Mutex($false, "PathMutex")
+
+if (!$mtx.WaitOne(5000)) {
+  throw "Could not acquire PATH mutex"
+}
+
+$Mingw32Root='C:\var\vcap\packages\mingw32\mingw32'
+
+$OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
+$AddedFolder="$Mingw32Root\bin"
+$NewPath=$OldPath+';'+$AddedFolder
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+$mtx.ReleaseMutex()

--- a/jobs/mingw64/spec
+++ b/jobs/mingw64/spec
@@ -7,3 +7,8 @@ templates:
 packages:
 - mingw64
 
+properties:
+  mingw64.install_on_path:
+    description: "Install on $PATH"
+    default: true
+

--- a/jobs/mingw64/templates/pre-start.ps1.erb
+++ b/jobs/mingw64/templates/pre-start.ps1.erb
@@ -12,8 +12,11 @@ if ($installOnPath) {
 
   $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
   $AddedFolder="C:\var\vcap\packages\mingw64\mingw64\bin"
-  $NewPath=$AddedFolder+';'+$OldPath
-  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+  if (-not $OldPath.Contains($AddedFolder)) {
+    $NewPath=$AddedFolder+';'+$OldPath
+    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+  }
 
   $mtx.ReleaseMutex()
 }

--- a/jobs/mingw64/templates/pre-start.ps1.erb
+++ b/jobs/mingw64/templates/pre-start.ps1.erb
@@ -1,15 +1,19 @@
 ﻿$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-$mtx = New-Object System.Threading.Mutex($false, "PathMutex")
+$installOnPath = [bool]$<%= p("mingw64.install_on_path") %>
 
-if (!$mtx.WaitOne(5000)) {
-  throw "Could not acquire PATH mutex"
+if ($installOnPath) {
+  $mtx = New-Object System.Threading.Mutex($false, "PathMutex")
+
+  if (!$mtx.WaitOne(5000)) {
+    throw "Could not acquire PATH mutex"
+  }
+
+  $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
+  $AddedFolder="C:\var\vcap\packages\mingw64\mingw64\bin"
+  $NewPath=$AddedFolder+';'+$OldPath
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+  $mtx.ReleaseMutex()
 }
-
-$OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-$AddedFolder="C:\var\vcap\packages\mingw64\mingw64\bin"
-$NewPath=$AddedFolder+';'+$OldPath
-Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
-
-$mtx.ReleaseMutex()

--- a/jobs/perl64/spec
+++ b/jobs/perl64/spec
@@ -1,0 +1,12 @@
+---
+name: perl64
+description: "This is a job that installs Strawberry Perl 64bit"
+
+templates:
+  pre-start.ps1.erb: bin/pre-start.ps1
+
+packages:
+  - perl64
+
+properties: {}
+

--- a/jobs/perl64/templates/pre-start.ps1.erb
+++ b/jobs/perl64/templates/pre-start.ps1.erb
@@ -7,7 +7,7 @@ if (!$mtx.WaitOne(5000)) {
   throw "Could not acquire PATH mutex"
 }
 
-$PerlRoot='C:\var\vcap\packages\perl'
+$PerlRoot='C:\var\vcap\packages\perl64\perl\bin'
 
 $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
 $AddedFolder="$PerlRoot"

--- a/jobs/perl64/templates/pre-start.ps1.erb
+++ b/jobs/perl64/templates/pre-start.ps1.erb
@@ -10,10 +10,13 @@ if (!$mtx.WaitOne(5000)) {
 $PerlRoot='C:\var\vcap\packages\perl64\perl\bin'
 
 $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-$AddedFolder="$PerlRoot"
-$NewPath=$OldPath+';'+$AddedFolder
-Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
 
-Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name GOROOT -Value $GoRoot
+if (-not $OldPath.Contains($PerlRoot)) {
+  $AddedFolder="$PerlRoot"
+  $NewPath=$OldPath+';'+$AddedFolder
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name GOROOT -Value $GoRoot
+}
 
 $mtx.ReleaseMutex()

--- a/jobs/perl64/templates/pre-start.ps1.erb
+++ b/jobs/perl64/templates/pre-start.ps1.erb
@@ -1,0 +1,19 @@
+﻿$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$mtx = New-Object System.Threading.Mutex($false, "PathMutex")
+
+if (!$mtx.WaitOne(5000)) {
+  throw "Could not acquire PATH mutex"
+}
+
+$PerlRoot='C:\var\vcap\packages\perl'
+
+$OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
+$AddedFolder="$PerlRoot"
+$NewPath=$OldPath+';'+$AddedFolder
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name GOROOT -Value $GoRoot
+
+$mtx.ReleaseMutex()

--- a/packages/cmake/packaging
+++ b/packages/cmake/packaging
@@ -2,6 +2,12 @@ $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
 $ZipFile=$(Get-Item cmake/cmake*.zip).FullName
-Expand-Archive -Path $ZipFile -DestinationPath $env:BOSH_INSTALL_TARGET
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+  Expand-Archive -Path $ZipFile -DestinationPath $env:BOSH_INSTALL_TARGET
+} else {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($ZipFile, $env:BOSH_INSTALL_TARGET)
+}
+
 Move-Item -Force $env:BOSH_INSTALL_TARGET/cmake-*/* $env:BOSH_INSTALL_TARGET
 Remove-Item -Force $env:BOSH_INSTALL_TARGET/cmake-*

--- a/packages/perl64/packaging
+++ b/packages/perl64/packaging
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
+
+$path=(Get-ChildItem "perl64/strawberry-perl-*-64bit.msi").FullName
+
+Start-Process -FilePath msiexec -ArgumentList "/i $path /passive /norestart INSTALLDIR=$BOSH_INSTALL_TARGET" -Wait -PassThru -NoNewWindow

--- a/packages/perl64/spec
+++ b/packages/perl64/spec
@@ -1,0 +1,7 @@
+---
+name: perl64
+
+dependencies: []
+
+files:
+- perl64/strawberry-perl-*-64bit.msi


### PR DESCRIPTION
 This PR adds perl64 and makes some updates to jobs:
- Cmake `pre-start` is compatible with powershell versions before v5
- Adds mingw64 to the `$env:PATH` by default. There is a BOSH property that lets you add mingw32 to the path which you could do as well (but you wouldn't want to because there would be a conflict).

