### PR TITLE
Fix paths to Go.exe after 1.24 upgrade

### DIFF
--- a/jobs/golang-1-windows/templates/pre-start.ps1
+++ b/jobs/golang-1-windows/templates/pre-start.ps1
@@ -7,7 +7,7 @@ if (!$mtx.WaitOne(300000)) {
   throw "Could not acquire PATH mutex"
 }
 
-$GoRoot='C:\var\vcap\packages\golang-1.23-windows\go'
+$GoRoot='C:\var\vcap\packages\golang-1.24-windows\go'
 
 $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
 $AddedFolder="$GoRoot\bin"

--- a/jobs/powershell-profile/templates/powershell-profile.ps1
+++ b/jobs/powershell-profile/templates/powershell-profile.ps1
@@ -3,6 +3,6 @@ $env:HKLM_ENV="HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environmen
 $env:PATH=(Get-ItemProperty -Path "$env:HKLM_ENV" -Name PATH).Path
 
 
-$env:GOPATH="C:\var\vcap\data\golang-1.23-windows\go"
-$env:GOBIN="C:\var\vcap\data\golang-1.23-windows\go\bin"
+$env:GOPATH="C:\var\vcap\data\golang-1.24-windows\go"
+$env:GOBIN="C:\var\vcap\data\golang-1.24-windows\go\bin"
 $env:PATH+=";$env:GOBIN"


### PR DESCRIPTION
The bots that bump Golang currently do not update the package paths in the job scripts. This has broken the installation of Go on Windows after the 1.23 -> 1.24 upgrade.