### PR TITLE
Fix stale golang-1.25-windows references after upgrade to 1.26

### DIFF
--- a/jobs/golang-1-windows/templates/pre-start.ps1
+++ b/jobs/golang-1-windows/templates/pre-start.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = "Stop";
+$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
 $mtx = New-Object System.Threading.Mutex($false, "PathMutex")
@@ -7,7 +7,7 @@ if (!$mtx.WaitOne(300000)) {
   throw "Could not acquire PATH mutex"
 }
 
-$GoRoot='C:\var\vcap\packages\golang-1.25-windows\go'
+$GoRoot='C:\var\vcap\packages\golang-1.26-windows\go'
 
 $OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
 $AddedFolder="$GoRoot\bin"

--- a/jobs/powershell-profile/templates/powershell-profile.ps1
+++ b/jobs/powershell-profile/templates/powershell-profile.ps1
@@ -1,8 +1,8 @@
-﻿# set PATH to all HKLM Environment
+# set PATH to all HKLM Environment
 $env:HKLM_ENV="HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
 $env:PATH=(Get-ItemProperty -Path "$env:HKLM_ENV" -Name PATH).Path
 
 
-$env:GOPATH="C:\var\vcap\data\golang-1.25-windows\go"
-$env:GOBIN="C:\var\vcap\data\golang-1.25-windows\go\bin"
+$env:GOPATH="C:\var\vcap\data\golang-1.26-windows\go"
+$env:GOBIN="C:\var\vcap\data\golang-1.26-windows\go\bin"
 $env:PATH+=";$env:GOBIN"


### PR DESCRIPTION
## Summary

The dependency bumper automatically updated to go1.26 but it left broken references to 1.25 behind. Unfortunately it looks like no tests caught this issue.

- Updates `golang-1-windows` job's `pre-start.ps1` to reference `golang-1.26-windows` instead of `golang-1.25-windows`
- Updates `powershell-profile` job's `powershell-profile.ps1` GOPATH/GOBIN paths to reference `golang-1.26-windows`

## Problem

After the package was upgraded from `golang-1.25-windows` to `golang-1.26-windows` (in v80.72.0), the job templates were not updated to match. This causes Go to be missing from the system PATH on any BOSH-deployed Windows worker using `windows-tools` >= 80.72.0, breaking all `go` commands with:

```
process_begin: CreateProcess(NULL, go run ..., ...) failed.
make (e=2): The system cannot find the file specified.
```

Fixes #43

## Test plan

- [ ] Deploy a Windows Concourse worker with this fix applied
- [ ] Verify `go version` works from a Concourse task on the worker
- [ ] Run a job that invokes `make units` (e.g. `stembuild-windows`) and confirm it passes

Made with [Cursor](https://cursor.com)