### PR TITLE
Enable mysql_native_password for backwards compatibility

### DIFF
--- a/packages/mysql/packaging
+++ b/packages/mysql/packaging
@@ -22,6 +22,7 @@ $iniFileDest="$dest\my.ini"
 basedir=${dest}
 datadir=C:\\var\\vcap\\data\\mysql
 port=3306
+mysql_native_password=ON
 "@ | Out-File $iniFileDest -Force -Encoding ASCII
 
 


### PR DESCRIPTION
Mysql 8.4 disabled mysql_native_password by default